### PR TITLE
add client certificate support for https

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="ntlm">NTLM Authentication</string>
     <string name="ntlm_summary">Enable to support NTLM / NTLM2 authentication
 		method</string>
+    <string name="certificate">Certificate</string>
+    <string name="certificate_summary">Client Certificate for HTTPS authentication</string>
     <string name="domain">Domain</string>
     <string name="domain_summary">Domain name for NTLM</string>
 

--- a/res/xml-v14/proxydroid_preference.xml
+++ b/res/xml-v14/proxydroid_preference.xml
@@ -92,6 +92,12 @@
         android:summary="@string/domain_summary"
         android:title="@string/domain">
     </EditTextPreference>
+
+    <EditTextPreference
+        android:key="certificate"
+        android:summary="@string/certificate_summary"
+        android:title="@string/certificate">
+    </EditTextPreference>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/fearute_cat">
     <CheckBoxPreference

--- a/res/xml/proxydroid_preference.xml
+++ b/res/xml/proxydroid_preference.xml
@@ -92,6 +92,12 @@
         android:summary="@string/domain_summary"
         android:title="@string/domain">
     </EditTextPreference>
+
+    <EditTextPreference
+        android:key="certificate"
+        android:summary="@string/certificate_summary"
+        android:title="@string/certificate">
+    </EditTextPreference>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/fearute_cat">
     <CheckBoxPreference

--- a/src/org/proxydroid/Profile.java
+++ b/src/org/proxydroid/Profile.java
@@ -42,6 +42,7 @@ public class Profile implements Serializable {
 	private String bypassAddrs;
 	private String user;
 	private String password;
+        private String certificate;
 	private String proxyedApps;
 	private boolean isAutoConnect = false;
 	private boolean isAutoSetProxy = false;
@@ -69,6 +70,7 @@ public class Profile implements Serializable {
 		bypassAddrs = settings.getString("bypassAddrs", "");
 		proxyedApps = settings.getString("Proxyed", "");
 		domain = settings.getString("domain", "");
+                certificate = settings.getString("certificate", "");
 
 		isAuth = settings.getBoolean("isAuth", false);
 		isNTLM = settings.getBoolean("isNTLM", false);
@@ -104,6 +106,7 @@ public class Profile implements Serializable {
 		ed.putBoolean("isNTLM", isNTLM);
 		ed.putString("domain", domain);
 		ed.putString("proxyType", proxyType);
+                ed.putString("certificate", certificate);
 		ed.putBoolean("isAutoConnect", isAutoConnect);
 		ed.putBoolean("isAutoSetProxy", isAutoSetProxy);
 		ed.putBoolean("isBypassApps", isBypassApps);
@@ -120,6 +123,7 @@ public class Profile implements Serializable {
 		user = "";
 		domain = "";
 		password = "";
+                certificate = "";
 		isAuth = false;
 		proxyType = "http";
 		isAutoConnect = false;
@@ -146,6 +150,7 @@ public class Profile implements Serializable {
 		obj.put("user", user);
 		obj.put("password", password);
 		obj.put("domain", domain);
+                obj.put("certificate", certificate);
 		obj.put("bypassAddrs", bypassAddrs);
 		obj.put("Proxyed", proxyedApps);
 
@@ -215,6 +220,7 @@ public class Profile implements Serializable {
 		user = jd.getString("user", "");
 		password = jd.getString("password", "");
 		domain = jd.getString("domain", "");
+                certificate = jd.getString("certificate", "");
 		bypassAddrs = jd.getString("bypassAddrs", "");
 		proxyedApps = jd.getString("Proxyed", "");
 
@@ -409,6 +415,21 @@ public class Profile implements Serializable {
 	 */
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	/**
+	 * @return the certificate
+	 */
+	public String getCertificate() {
+		return certificate;
+	}
+
+	/**
+	 * @param certificate
+	 *            the certificate to set
+	 */
+	public void setCertificate(String certificate) {
+		this.certificate = certificate;
 	}
 
 	/**

--- a/src/org/proxydroid/ProxyDroid.java
+++ b/src/org/proxydroid/ProxyDroid.java
@@ -133,6 +133,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
   private EditTextPreference userText;
   private EditTextPreference passwordText;
   private EditTextPreference domainText;
+  private EditTextPreference certificateText;
   private ListPreferenceMultiSelect ssidList;
   private ListPreference proxyTypeList;
   private Preference isRunningCheck;
@@ -318,6 +319,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     userText = (EditTextPreference) findPreference("user");
     passwordText = (EditTextPreference) findPreference("password");
     domainText = (EditTextPreference) findPreference("domain");
+    certificateText = (EditTextPreference) findPreference("certificate");
     bypassAddrs = findPreference("bypassAddrs");
     ssidList = (ListPreferenceMultiSelect) findPreference("ssid");
     proxyTypeList = (ListPreference) findPreference("proxyType");
@@ -440,6 +442,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
       bundle.putString("bypassAddrs", mProfile.getBypassAddrs());
       bundle.putString("password", mProfile.getPassword());
       bundle.putString("domain", mProfile.getDomain());
+      bundle.putString("certificate", mProfile.getCertificate());
 
       bundle.putString("proxyType", mProfile.getProxyType());
       bundle.putBoolean("isAutoSetProxy", mProfile.isAutoSetProxy());
@@ -483,6 +486,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     userText.setText(mProfile.getUser());
     passwordText.setText(mProfile.getPassword());
     domainText.setText(mProfile.getDomain());
+    certificateText.setText(mProfile.getCertificate());
     proxyTypeList.setValue(mProfile.getProxyType());
     ssidList.setValue(mProfile.getSsid());
 
@@ -523,6 +527,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     userText.setEnabled(false);
     passwordText.setEnabled(false);
     domainText.setEnabled(false);
+    certificateText.setEnabled(false);
     ssidList.setEnabled(false);
     proxyTypeList.setEnabled(false);
     proxyedApps.setEnabled(false);
@@ -553,6 +558,9 @@ public class ProxyDroid extends SherlockPreferenceActivity
       passwordText.setEnabled(true);
       isNTLMCheck.setEnabled(true);
       if (isNTLMCheck.isChecked()) domainText.setEnabled(true);
+    }
+    if ("https".equals(proxyTypeList.getValue())){
+        certificateText.setEnabled(true);
     }
     if (!isAutoSetProxyCheck.isChecked()) {
       proxyedApps.setEnabled(true);
@@ -624,6 +632,10 @@ public class ProxyDroid extends SherlockPreferenceActivity
       domainText.setEnabled(false);
     }
 
+    if (!"https".equals(settings.getString("proxyType", ""))){
+      certificateText.setEnabled(false);
+    }
+
     Editor edit = settings.edit();
 
     if (Utils.isWorking()) {
@@ -670,6 +682,9 @@ public class ProxyDroid extends SherlockPreferenceActivity
     }
     if (!settings.getString("user", "").equals("")) {
       userText.setSummary(settings.getString("user", getString(R.string.user_summary)));
+    }
+    if (!settings.getString("certificate", "").equals("")) {
+      certificateText.setSummary(settings.getString("certificate", getString(R.string.certificate_summary)));
     }
     if (!settings.getString("bypassAddrs", "").equals("")) {
       bypassAddrs.setSummary(
@@ -804,6 +819,14 @@ public class ProxyDroid extends SherlockPreferenceActivity
         domainText.setEnabled(true);
       }
     }
+    
+    if (key.equals("proxyType")){
+      if (!"https".equals(settings.getString("proxyType", ""))){
+        certificateText.setEnabled(false);
+      } else {
+        certificateText.setEnabled(true);
+      }
+    }
 
     if (key.equals("isAutoConnect")) {
       if (settings.getBoolean("isAutoConnect", false)) {
@@ -861,6 +884,12 @@ public class ProxyDroid extends SherlockPreferenceActivity
         domainText.setSummary(getString(R.string.domain_summary));
       } else {
         domainText.setSummary(settings.getString("domain", ""));
+      }
+    } else if (key.equals("proxyType")) {
+      if (settings.getString("proxyType", "").equals("")) {
+        certificateText.setSummary(getString(R.string.certificate_summary));
+      } else {
+        certificateText.setSummary(settings.getString("certificate", ""));
       }
     } else if (key.equals("bypassAddrs")) {
       if (settings.getString("bypassAddrs", "").equals("")) {

--- a/src/org/proxydroid/ProxyDroidService.java
+++ b/src/org/proxydroid/ProxyDroidService.java
@@ -118,6 +118,7 @@ public class ProxyDroidService extends Service {
   private String password;
   private String domain;
   private String proxyType = "http";
+  private String certificate;
   private String auth = "false";
   private boolean isAuth = false;
   private boolean isNTLM = false;
@@ -258,9 +259,20 @@ public class ProxyDroidService extends Service {
           String conf = "debug = 0\n" + "client = yes\n" + "pid = " + BASE + "stunnel.pid\n"
               + "[https]\n" + "sslVersion = all\n" + "accept = 127.0.0.1:8126\n"
               + "connect = " + host + ":" + port + "\n";
+          if (0 != certificate.length())
+              conf = conf + "cert = " + BASE + "client.pem\n";
           fs.write(conf.getBytes());
           fs.flush();
           fs.close();
+
+          // Certificate file for Stunnel
+          if (0 != certificate.length()){
+              fs = new FileOutputStream(BASE + "client.pem");
+              fs.write(certificate.getBytes());
+              fs.flush();
+              fs.close();
+              Utils.runCommand("chmod 0600 " + BASE + "client.pem");
+          }
 
           // Start stunnel here
           Utils.runRootCommand(BASE + "stunnel " + BASE + "stunnel.conf");
@@ -695,6 +707,9 @@ public class ProxyDroidService extends Service {
       domain = bundle.getString("domain");
     else
       domain = "";
+
+    if ("https".equals(proxyType))
+        certificate = bundle.getString("certificate");
 
     new Thread(new Runnable() {
       @Override


### PR DESCRIPTION
A new text preference field "certificate" is added to store the certificate. As specified in stunnel, the certificate should be in PEM format, starting with a private key and immediately followed by the corresponding certificate.  Plain text certificate should not be included.

The content of such a PEM certificate is to be paste into the 'Certificate' field in the UI. The field will be enabled when proxyType "HTTPS" is selected. For HTTPS proxies which do not require a client certificate, the field may be leave empty.
