### PR TITLE
run daemon as unprivilleged user

### DIFF
--- a/assets/proxy.sh
+++ b/assets/proxy.sh
@@ -130,11 +130,6 @@ redsocks {
  ;;
 stop)
 
-  killall -9 redsocks
-  killall -9 cntlm
-  killall -9 stunnel
-  killall -9 tproxy
-  
   kill -9 `cat $DIR/redsocks.pid`
   
   rm $DIR/redsocks.pid

--- a/src/org/proxydroid/ProxyDroid.java
+++ b/src/org/proxydroid/ProxyDroid.java
@@ -1139,7 +1139,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
         + "kill -9 `cat /data/data/org.proxydroid/shrpx.pid`\n"
         + "kill -9 `cat /data/data/org.proxydroid/cntlm.pid`\n");
 
-    Utils.runRootCommand("chmod 700 /data/data/org.proxydroid/iptables\n"
+    Utils.runCommand("chmod 700 /data/data/org.proxydroid/iptables\n"
         + "chmod 700 /data/data/org.proxydroid/redsocks\n"
         + "chmod 700 /data/data/org.proxydroid/proxy.sh\n"
         + "chmod 700 /data/data/org.proxydroid/cntlm\n"

--- a/src/org/proxydroid/ProxyDroid.java
+++ b/src/org/proxydroid/ProxyDroid.java
@@ -1134,12 +1134,9 @@ public class ProxyDroid extends SherlockPreferenceActivity
         + " -t nat -F OUTPUT\n"
         + ProxyDroidService.BASE
         + "proxy.sh stop\n"
-        + "kill -9 `cat /data/data/org.proxydroid/tproxy.pid`\n"
-        + "kill -9 `cat /data/data/org.proxydroid/stunnel.pid`\n"
-        + "kill -9 `cat /data/data/org.proxydroid/shrpx.pid`\n"
-        + "kill -9 `cat /data/data/org.proxydroid/cntlm.pid`\n");
-
-    Utils.runCommand("chmod 700 /data/data/org.proxydroid/iptables\n"
+        + "kill -9 `cat /data/data/org.proxydroid/*.pid`\n");
+    Utils.runCommand("rm /data/data/org.proxydroid/*.pid\n"
+        + "chmod 700 /data/data/org.proxydroid/iptables\n"
         + "chmod 700 /data/data/org.proxydroid/redsocks\n"
         + "chmod 700 /data/data/org.proxydroid/proxy.sh\n"
         + "chmod 700 /data/data/org.proxydroid/cntlm\n"

--- a/src/org/proxydroid/ProxyDroidService.java
+++ b/src/org/proxydroid/ProxyDroidService.java
@@ -535,6 +535,7 @@ public class ProxyDroidService extends Service {
 
     sb.append(BASE + "proxy.sh stop\n");
     sb.append("kill -9 `cat /data/data/org.proxydroid/*.pid`\n");
+    sb.append("rm /data/data/org.proxydroid/*.pid\n");
 
     new Thread() {
       @Override

--- a/src/org/proxydroid/ProxyDroidService.java
+++ b/src/org/proxydroid/ProxyDroidService.java
@@ -533,20 +533,8 @@ public class ProxyDroidService extends Service {
 
     final StringBuilder sb = new StringBuilder();
 
-    if ("https".equals(proxyType)) {
-      sb.append("kill -9 `cat /data/data/org.proxydroid/stunnel.pid`\n");
-    }
-
-    if ("spdy".equals(proxyType)) {
-      sb.append("kill -9 `cat /data/data/org.proxydroid/shrpx.pid`\n");
-    }
-
-    if (isAuth && isNTLM) {
-      sb.append("kill -9 `cat /data/data/org.proxydroid/cntlm.pid`\n"
-          + "kill -9 `cat /data/data/org.proxydroid/tproxy.pid`\n");
-    }
-
     sb.append(BASE + "proxy.sh stop\n");
+    sb.append("kill -9 `cat /data/data/org.proxydroid/*.pid`\n");
 
     new Thread() {
       @Override

--- a/src/org/proxydroid/ProxyDroidService.java
+++ b/src/org/proxydroid/ProxyDroidService.java
@@ -275,9 +275,9 @@ public class ProxyDroidService extends Service {
           }
 
           // Start stunnel here
-          Utils.runRootCommand(BASE + "stunnel " + BASE + "stunnel.conf");
+          Utils.runCommand(BASE + "stunnel " + BASE + "stunnel.conf");
         } else if ("spdy".equals(proxyType)) {
-          Utils.runRootCommand(BASE + "shrpx -D -k -p -f 127.0.0.1,8126 -b " + host + "," + port
+          Utils.runCommand(BASE + "shrpx -D -k -p -f 127.0.0.1,8126 -b " + host + "," + port
               + " --pid-file=" + BASE + "shrpx.pid");
         }
 
@@ -289,7 +289,7 @@ public class ProxyDroidService extends Service {
       }
 
       if (proxyType.equals("http") && isAuth && isNTLM) {
-        Utils.runRootCommand(BASE + "proxy.sh start http 127.0.0.1 8025 false\n" + BASE
+        Utils.runCommand(BASE + "proxy.sh start http 127.0.0.1 8025 false\n" + BASE
             + "cntlm -P " + BASE + "cntlm.pid -l 8025 -u " + user
             + (!domain.equals("") ? "@" + domain : "@local") + " -p " + password + " "
             + proxyHost + ":" + proxyPort + "\n" + BASE
@@ -298,7 +298,7 @@ public class ProxyDroidService extends Service {
         final String u = Utils.preserve(user);
         final String p = Utils.preserve(password);
 
-        Utils.runRootCommand(BASE + "proxy.sh start" + " " + proxyType + " " + proxyHost
+        Utils.runCommand(BASE + "proxy.sh start" + " " + proxyType + " " + proxyHost
             + " " + proxyPort + " " + auth + " \"" + u + "\" \"" + p + "\"");
       }
 
@@ -387,7 +387,7 @@ public class ProxyDroidService extends Service {
    */
   public boolean handleCommand() {
 
-    Utils.runRootCommand("chmod 700 /data/data/org.proxydroid/iptables\n"
+    Utils.runCommand("chmod 700 /data/data/org.proxydroid/iptables\n"
         + "chmod 700 /data/data/org.proxydroid/redsocks\n"
         + "chmod 700 /data/data/org.proxydroid/proxy.sh\n"
         + "chmod 700 /data/data/org.proxydroid/cntlm\n"
@@ -529,9 +529,9 @@ public class ProxyDroidService extends Service {
 
   private void onDisconnect() {
 
-    final StringBuilder sb = new StringBuilder();
+    Utils.runRootCommand(Utils.getIptables() + " -t nat -F OUTPUT\n");
 
-    sb.append(Utils.getIptables()).append(" -t nat -F OUTPUT\n");
+    final StringBuilder sb = new StringBuilder();
 
     if ("https".equals(proxyType)) {
       sb.append("kill -9 `cat /data/data/org.proxydroid/stunnel.pid`\n");
@@ -551,7 +551,7 @@ public class ProxyDroidService extends Service {
     new Thread() {
       @Override
       public void run() {
-        Utils.runRootCommand(sb.toString());
+        Utils.runCommand(sb.toString());
       }
     }.start();
 


### PR DESCRIPTION
Only iptables needs to be run as root. Running daemons as root is a security risk.

As pid files created by daemons in previous version are owned by root, daemons run as unprivilleged user are not able to access it any more. Hence, the app data may need to be cleared (although I have not test whether it would work without a data clearing).