### PR TITLE
fix bug: "too many open files"

### DIFF
--- a/src/main/assets/proxy.sh
+++ b/src/main/assets/proxy.sh
@@ -1,5 +1,7 @@
 #!/system/bin/sh
 
+ulimit -HSn 4096
+
 DIR=/data/data/org.proxydroid
 type=$2
 host=$3


### PR DESCRIPTION
In some android 5,redsock will say about  "too many open files",and does not work,
because redsocks open socket connect too many than $(ulimit -n)
so I add "ulimit -HSn 4096"
let it be enough.
poor English.Let me describe in Chinese.
我用了很多安卓手机，发现在许多安卓5上，会出现成功转发了数据包却没有成功代理，
于是把redsocks改成调试模式，发现"too many open files"
虽然不明白默认的上限$(ulimit -n)1024为什么会不够，
但是我把上限设置成4倍ulimit -HSn 4096，问题就不再出现了，