### PR TITLE
avoid NullPointerException

### DIFF
--- a/src/main/java/org/proxydroid/ProxyDroidService.java
+++ b/src/main/java/org/proxydroid/ProxyDroidService.java
@@ -259,14 +259,14 @@ public class ProxyDroidService extends Service {
           String conf = "debug = 0\n" + "client = yes\n" + "pid = " + BASE + "stunnel.pid\n"
               + "[https]\n" + "sslVersion = all\n" + "accept = 127.0.0.1:8126\n"
               + "connect = " + host + ":" + port + "\n";
-          if (0 != certificate.length())
+          if (null != certificate && 0 != certificate.length())
               conf = conf + "cert = " + BASE + "client.pem\n";
           fs.write(conf.getBytes());
           fs.flush();
           fs.close();
 
           // Certificate file for Stunnel
-          if (0 != certificate.length()){
+          if (null != certificate && 0 != certificate.length()){
               fs = new FileOutputStream(BASE + "client.pem");
               fs.write(certificate.getBytes());
               fs.flush();


### PR DESCRIPTION
E/ProxyDroidService(20295): Error setting up port forward during connect
E/ProxyDroidService(20295): java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
E/ProxyDroidService(20295):     at org.proxydroid.ProxyDroidService.enableProxy(ProxyDroidService.java:263)
E/ProxyDroidService(20295):     at org.proxydroid.ProxyDroidService.handleCommand(ProxyDroidService.java:394)
E/ProxyDroidService(20295):     at org.proxydroid.ProxyDroidService$3.run(ProxyDroidService.java:715)
E/ProxyDroidService(20295):     at java.lang.Thread.run(Thread.java:818)