### PR TITLE
Add never bound ssid list

### DIFF
--- a/src/main/java/org/proxydroid/ConnectivityBroadcastReceiver.java
+++ b/src/main/java/org/proxydroid/ConnectivityBroadcastReceiver.java
@@ -107,7 +107,7 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver {
         for (String profile : profileValues) {
           String profileString = settings.getString(profile, "");
           mProfile.decodeJson(profileString);
-          curSSID = onlineSSID(context, mProfile.getSsid());
+          curSSID = onlineSSID(context, mProfile.getSsid(), mProfile.getExcludedSsid());
           if (mProfile.isAutoConnect() && curSSID != null) {
             // Enable auto connect
             autoConnect = true;
@@ -181,8 +181,9 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver {
     });
   }
 
-  public String onlineSSID(Context context, String ssid) {
+  public String onlineSSID(Context context, String ssid, String excludedSsid) {
     String ssids[] = ListPreferenceMultiSelect.parseStoredValue(ssid);
+    String excludedSsids[] = ListPreferenceMultiSelect.parseStoredValue(excludedSsid);
     if (ssids == null)
       return null;
     if (ssids.length < 1)
@@ -210,6 +211,15 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver {
     if (current == null || "".equals(current))
       return null;
     current = current.replace("\"", "");
+
+    if (excludedSsids != null) {
+        for (String item : excludedSsids) {
+            if (current.equals(item)) {
+                return null; // Never connect proxy on excluded ssid
+            }
+        }
+    }
+
     for (String item : ssids) {
       if (Constraints.WIFI_AND_3G.equals(item))
         return item;

--- a/src/main/java/org/proxydroid/Profile.java
+++ b/src/main/java/org/proxydroid/Profile.java
@@ -54,6 +54,7 @@ public class Profile implements Serializable {
 
 	private String domain;
 	private String ssid;
+	private String excludedSsid;
 
 	public Profile() {
 		init();
@@ -67,6 +68,7 @@ public class Profile implements Serializable {
 		user = settings.getString("user", "");
 		password = settings.getString("password", "");
 		ssid = settings.getString("ssid", "");
+		excludedSsid = settings.getString("excludedSsid", "");
 		bypassAddrs = settings.getString("bypassAddrs", "");
 		proxyedApps = settings.getString("Proxyed", "");
 		domain = settings.getString("domain", "");
@@ -113,6 +115,7 @@ public class Profile implements Serializable {
 		ed.putBoolean("isPAC", isPAC);
 		ed.putBoolean("isDNSProxy", isDNSProxy);
 		ed.putString("ssid", ssid);
+		ed.putString("excludedSsid", excludedSsid);
 		ed.commit();
 	}
 
@@ -128,6 +131,7 @@ public class Profile implements Serializable {
 		proxyType = "http";
 		isAutoConnect = false;
 		ssid = "";
+		excludedSsid = "";
 		isNTLM = false;
 		bypassAddrs = "";
 		proxyedApps = "";
@@ -145,6 +149,7 @@ public class Profile implements Serializable {
 		JSONObject obj = new JSONObject();
 		obj.put("name", name);
 		obj.put("ssid", ssid);
+		obj.put("excludedSsid", excludedSsid);
 		obj.put("host", host);
 		obj.put("proxyType", proxyType);
 		obj.put("user", user);
@@ -215,6 +220,7 @@ public class Profile implements Serializable {
 
 		name = jd.getString("name", "");
 		ssid = jd.getString("ssid", "");
+		excludedSsid = jd.getString("excludedSsid", "");
 		host = jd.getString("host", "");
 		proxyType = jd.getString("proxyType", "http");
 		user = jd.getString("user", "");
@@ -320,11 +326,26 @@ public class Profile implements Serializable {
 	}
 
 	/**
+	 * @return the excluded ssid
+	 */
+	public String getExcludedSsid() {
+		return excludedSsid;
+	}
+
+	/**
 	 * @param ssid
 	 *            the ssid to set
 	 */
 	public void setSsid(String ssid) {
 		this.ssid = ssid;
+	}
+
+	/**
+	 * @param ssid
+	 *            the excluded ssid to set
+	 */
+	public void setExcludedSsid(String ssid) {
+		this.excludedSsid = ssid;
 	}
 
 	/**

--- a/src/main/java/org/proxydroid/ProxyDroid.java
+++ b/src/main/java/org/proxydroid/ProxyDroid.java
@@ -92,6 +92,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Arrays;
 import org.proxydroid.db.DNSResponse;
 import org.proxydroid.db.DatabaseHelper;
 import org.proxydroid.utils.Constraints;
@@ -135,6 +136,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
   private EditTextPreference domainText;
   private EditTextPreference certificateText;
   private ListPreferenceMultiSelect ssidList;
+  private ListPreferenceMultiSelect excludedSsidList;
   private ListPreference proxyTypeList;
   private Preference isRunningCheck;
   private CheckBoxPreference isBypassAppsCheck;
@@ -252,7 +254,9 @@ public class ProxyDroid extends SherlockPreferenceActivity
     WifiManager wm = (WifiManager) this.getSystemService(Context.WIFI_SERVICE);
     List<WifiConfiguration> wcs = wm.getConfiguredNetworks();
     String[] ssidEntries = null;
+    String[] pureSsid = null;
     int n = 3;
+    int wifiIndex = n;
 
     if (wcs == null) {
       ssidEntries = new String[n];
@@ -277,6 +281,10 @@ public class ProxyDroid extends SherlockPreferenceActivity
     }
     ssidList.setEntries(ssidEntries);
     ssidList.setEntryValues(ssidEntries);
+
+    pureSsid = Arrays.copyOfRange(ssidEntries, wifiIndex, ssidEntries.length);
+    excludedSsidList.setEntries(pureSsid);
+    excludedSsidList.setEntryValues(pureSsid);
   }
 
   @Override
@@ -332,6 +340,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     certificateText = (EditTextPreference) findPreference("certificate");
     bypassAddrs = findPreference("bypassAddrs");
     ssidList = (ListPreferenceMultiSelect) findPreference("ssid");
+    excludedSsidList = (ListPreferenceMultiSelect) findPreference("excludedSsid");
     proxyTypeList = (ListPreference) findPreference("proxyType");
     proxyedApps = findPreference("proxyedApps");
     profileList = (ListPreference) findPreference("profile");
@@ -499,6 +508,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     certificateText.setText(mProfile.getCertificate());
     proxyTypeList.setValue(mProfile.getProxyType());
     ssidList.setValue(mProfile.getSsid());
+    excludedSsidList.setValue(mProfile.getExcludedSsid());
 
     isAuthCheck.setChecked(mProfile.isAuth());
     isNTLMCheck.setChecked(mProfile.isNTLM());
@@ -539,6 +549,7 @@ public class ProxyDroid extends SherlockPreferenceActivity
     domainText.setEnabled(false);
     certificateText.setEnabled(false);
     ssidList.setEnabled(false);
+    excludedSsidList.setEnabled(false);
     proxyTypeList.setEnabled(false);
     proxyedApps.setEnabled(false);
     profileList.setEnabled(false);
@@ -576,7 +587,10 @@ public class ProxyDroid extends SherlockPreferenceActivity
       proxyedApps.setEnabled(true);
       isBypassAppsCheck.setEnabled(true);
     }
-    if (isAutoConnectCheck.isChecked()) ssidList.setEnabled(true);
+    if (isAutoConnectCheck.isChecked()) {
+        ssidList.setEnabled(true);
+        excludedSsidList.setEnabled(true);
+    }
 
     isDNSProxyCheck.setEnabled(true);
     profileList.setEnabled(true);
@@ -621,8 +635,10 @@ public class ProxyDroid extends SherlockPreferenceActivity
 
     if (settings.getBoolean("isAutoConnect", false)) {
       ssidList.setEnabled(true);
+      excludedSsidList.setEnabled(true);
     } else {
       ssidList.setEnabled(false);
+      excludedSsidList.setEnabled(false);
     }
 
     if (settings.getBoolean("isPAC", false)) {
@@ -689,6 +705,9 @@ public class ProxyDroid extends SherlockPreferenceActivity
 
     if (!settings.getString("ssid", "").equals("")) {
       ssidList.setSummary(settings.getString("ssid", ""));
+    }
+    if (!settings.getString("excludedSsid", "").equals("")) {
+      excludedSsidList.setSummary(settings.getString("excludedSsid", ""));
     }
     if (!settings.getString("user", "").equals("")) {
       userText.setSummary(settings.getString("user", getString(R.string.user_summary)));
@@ -842,8 +861,10 @@ public class ProxyDroid extends SherlockPreferenceActivity
       if (settings.getBoolean("isAutoConnect", false)) {
         loadNetworkList();
         ssidList.setEnabled(true);
+        excludedSsidList.setEnabled(true);
       } else {
         ssidList.setEnabled(false);
+        excludedSsidList.setEnabled(false);
       }
     }
 
@@ -882,6 +903,12 @@ public class ProxyDroid extends SherlockPreferenceActivity
         ssidList.setSummary(getString(R.string.ssid_summary));
       } else {
         ssidList.setSummary(settings.getString("ssid", ""));
+      }
+    } else if (key.equals("excludedSsid")) {
+      if (settings.getString("excludedSsid", "").equals("")) {
+        excludedSsidList.setSummary(getString(R.string.excluded_ssid_summary));
+      } else {
+        excludedSsidList.setSummary(settings.getString("excludedSsid", ""));
       }
     } else if (key.equals("user")) {
       if (settings.getString("user", "").equals("")) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -77,9 +77,13 @@
     <string name="ssid">Bound Network</string>
     <string name="ssid_summary">Bind your proxy setting to 2G/3G Network or
 		specified SSID</string>
+    <string name="excluded_ssid">Never Bound these WiFi SSID</string>
+    <string name="excluded_ssid_summary">Never bind the proxy setting to specified SSID</string>
 
     <string-array name="ssid_default_values"></string-array>
     <string-array name="ssid_default_entries"></string-array>
+    <string-array name="excluded_ssid_default_values"></string-array>
+    <string-array name="excluded_ssid_default_entries"></string-array>
 
     <string name="auto_set_proxy">Global Proxy</string>
     <string name="auto_set_proxy_summary">Enable the global proxy (needs ROOT permission

--- a/src/main/res/xml-v14/proxydroid_preference.xml
+++ b/src/main/res/xml-v14/proxydroid_preference.xml
@@ -56,6 +56,15 @@
         android:summary="@string/ssid_summary"
         android:title="@string/ssid"/>
 
+    <com.ksmaze.android.preference.ListPreferenceMultiSelect
+        android:defaultValue=""
+        android:dialogTitle="@string/excluded_ssid"
+        android:entries="@array/excluded_ssid_default_entries"
+        android:entryValues="@array/excluded_ssid_default_values"
+        android:key="excludedSsid"
+        android:summary="@string/excluded_ssid_summary"
+        android:title="@string/excluded_ssid"/>
+
     <Preference
         android:key="bypassAddrs"
         android:summary="@string/set_bypass_summary"

--- a/src/main/res/xml/proxydroid_preference.xml
+++ b/src/main/res/xml/proxydroid_preference.xml
@@ -56,6 +56,15 @@
         android:summary="@string/ssid_summary"
         android:title="@string/ssid"/>
 
+    <com.ksmaze.android.preference.ListPreferenceMultiSelect
+        android:defaultValue=""
+        android:dialogTitle="@string/excluded_ssid"
+        android:entries="@array/excluded_ssid_default_entries"
+        android:entryValues="@array/excluded_ssid_default_values"
+        android:key="excludedSsid"
+        android:summary="@string/excluded_ssid_summary"
+        android:title="@string/excluded_ssid"/>
+
     <Preference
         android:key="bypassAddrs"
         android:summary="@string/set_bypass_summary"


### PR DESCRIPTION
Never connect to the specified profile when current ssid is in the list.

Tested on Nexus 5x, Android 6.0.1.
