### PR TITLE
Add HTTPS support to PAC files

### DIFF
--- a/src/main/java/com/btr/proxy/selector/pac/PacProxySelector.java
+++ b/src/main/java/com/btr/proxy/selector/pac/PacProxySelector.java
@@ -16,6 +16,7 @@ public class PacProxySelector {
 	// private static final String PAC_PROXY = "PROXY";
 	private static final String PAC_SOCKS = "SOCKS";
 	private static final String PAC_DIRECT = "DIRECT";
+	private static final String PAC_HTTPS = "HTTPS";
 
 	private final static String TAG = "ProxyDroid.PAC";
 
@@ -121,9 +122,15 @@ public class PacProxySelector {
 		if (proxyDef.toUpperCase().startsWith(PAC_SOCKS)) {
 			type = Proxy.TYPE_SOCKS5;
 		}
+		if (proxyDef.toUpperCase().startsWith(PAC_HTTPS)) {
+			type = Proxy.TYPE_HTTPS;
+		}
 
 		String host = proxyDef.substring(6);
 		Integer port = 80;
+		if (type.equals(Proxy.TYPE_HTTPS)) {
+			port = 443;
+		}
 
 		// Split port from host
 		int indexOfPort = host.indexOf(':');

--- a/src/main/java/com/btr/proxy/selector/pac/Proxy.java
+++ b/src/main/java/com/btr/proxy/selector/pac/Proxy.java
@@ -5,6 +5,7 @@ public class Proxy {
 	public final static Proxy NO_PROXY = new Proxy(null, 0, null);
 
 	public final static String TYPE_HTTP = "http";
+	public final static String TYPE_HTTPS = "https";
 	public final static String TYPE_SOCKS4 = "socks4";
 	public final static String TYPE_SOCKS5 = "socks5";
 


### PR DESCRIPTION
I know that there is HTTPS support in the app but it doesn't work with PAC files which contains something like `HTTPS host:port` in it. So I've made tiny change to add support to the feature. I didn't test it though.