### PR TITLE
Enable basic authentication by default

### DIFF
--- a/app/src/main/cpp/redsocks/http-connect.c
+++ b/app/src/main/cpp/redsocks/http-connect.c
@@ -218,6 +218,9 @@ static struct evbuffer *httpc_mkconnect(redsocks_client *client)
 					"CONNECT", uri, auth->last_auth_count, cnounce); // method, path, nc, cnounce
 			auth_scheme = "Digest";
 		}
+	} else if (client->instance && client->instance->config.login && client->instance->config.password) {
+		auth_string = basic_authentication_encode(client->instance->config.login, client->instance->config.password);
+		auth_scheme = "Basic";
 	}
 
 	if (auth_string == NULL) {


### PR DESCRIPTION
I am developer of [VProxy](https://github.com/vproxy666/v-proxy), an HTTPS Forward proxy hidden in HTTPS web site.

VProxy pretends to be an HTTPS web site and only handles HTTPS proxy requests when the supplied credentials are valid. VProxy does not support challenge–response authentication for its HTTPS proxy because that would make it possible to detect it is running an HTTPS proxy.

As a result, VProxy works as reverse proxy when the credentials in HTTPS proxy request are missing or invalid. In this case, VProxy does not response HTTP error code 401 or 407 error challenge–response authentication will not be triggered.

This PR set basic authentization header by default when username and password are supplied. It will not break exsiting logic -- for classic http proxy when they response 401/407 error, the previous logic is applied.


