### PR TITLE
Improve magisk compatibility on AOSP Userdebug build

### DIFF
--- a/app/src/main/java/org/proxydroid/utils/Utils.java
+++ b/app/src/main/java/org/proxydroid/utils/Utils.java
@@ -24,7 +24,7 @@ public class Utils {
 
   public final static String TAG = "ProxyDroid";
   public final static String DEFAULT_SHELL = "/system/bin/sh";
-  public final static String DEFAULT_ROOTS[] = {"/system/bin/su", "/system/xbin/su", "/su/bin/su", "/su/xbin/su", "/sbin/su", "/magisk/.core/bin/su"};
+  public final static String DEFAULT_ROOTS[] = {"/sbin/su", "/system/bin/su", "/system/xbin/su", "/su/bin/su", "/su/xbin/su", "/magisk/.core/bin/su"};
   public final static String DEFAULT_IPTABLES = "iptables";
   public final static String ALTERNATIVE_IPTABLES = "/system/bin/iptables";
   public final static int TIME_OUT = -99;


### PR DESCRIPTION
On a userdebug build device with magisk installed, two `su` files exist on the same system:
- `/system/xbin/su` - added by userdebug config, restricted to `root` and `shell` users
- `/sbin/su` - added by magisk

Despite the fact that magisk's `su` is available, the default logic will attempt to test for `/system/xbin/su` first, resulting in a failed attempt and empty `ScriptRunner` result. 

Given magisk has gained great popularity over the years, it may worth considering to move `/sbin/su` to the first of `DEFAULT_ROOTS` so as to improve the overall compatibility.