### PR TITLE
Bump SDK levels for Google Play (target/compile 35, min 24)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ if (localPropsFile.exists()) {
 
 android {
     namespace 'org.proxydroid'
-    compileSdk 34
+    compileSdk 35
     ndkVersion "25.1.8937393"
 
     signingConfigs {
@@ -29,8 +29,8 @@ android {
 
     defaultConfig {
         applicationId "org.proxydroid"
-        minSdk 21
-        targetSdk 33
+        minSdk 24
+        targetSdk 35
         versionCode 74
         versionName "3.4.0"
 
@@ -76,7 +76,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.3'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 
     packagingOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ if (localPropsFile.exists()) {
 
 android {
     namespace 'org.proxydroid'
-    compileSdk 35
+    compileSdk 34
     ndkVersion "25.1.8937393"
 
     signingConfigs {
@@ -76,24 +76,13 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.15'
+        kotlinCompilerExtensionVersion '1.5.3'
     }
 
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
-    }
-}
-
-// rust-android-gradle 0.9.6 ends up registering its build/rustJniLibs/<abi>
-// directory in jniLibs.srcDirs twice under AGP 8.5+, causing
-// mergeJniLibFolders to fail with "Duplicate resources" on every ABI's .so.
-// Deduplicate srcDirs at configure time. MergeSourceSetFolders is not a
-// Copy task, so duplicatesStrategy doesn't help here.
-afterEvaluate {
-    android.sourceSets.configureEach { sourceSet ->
-        sourceSet.jniLibs.srcDirs = sourceSet.jniLibs.srcDirs.toSet().toList()
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,14 +83,18 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
-        // rust-android-gradle (0.9.6) registers its build/rustJniLibs/<abi>
-        // outputs into jniLibs.srcDirs, but AGP 8.5+ also sees the same
-        // path via the cargoBuild task output, which makes mergeJniLibFolders
-        // fail with "Duplicate resources". Pick the first copy for our .so.
-        jniLibs {
-            pickFirsts += ['**/libproxydroid_tun2socks.so']
-        }
     }
+}
+
+// rust-android-gradle 0.9.6 registers its build/rustJniLibs/<abi> output as a
+// JNI source dir, while AGP 8.5+ also captures the same path via the
+// cargoBuild task outputs, making mergeJniLibFolders see each .so twice and
+// fail with "Duplicate resources". Tell the merge Copy task to silently keep
+// one copy.
+tasks.matching {
+    it.name.startsWith("merge") && it.name.endsWith("JniLibFolders")
+}.configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 cargo {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,13 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+        // rust-android-gradle (0.9.6) registers its build/rustJniLibs/<abi>
+        // outputs into jniLibs.srcDirs, but AGP 8.5+ also sees the same
+        // path via the cargoBuild task output, which makes mergeJniLibFolders
+        // fail with "Duplicate resources". Pick the first copy for our .so.
+        jniLibs {
+            pickFirsts += ['**/libproxydroid_tun2socks.so']
+        }
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,15 +86,15 @@ android {
     }
 }
 
-// rust-android-gradle 0.9.6 registers its build/rustJniLibs/<abi> output as a
-// JNI source dir, while AGP 8.5+ also captures the same path via the
-// cargoBuild task outputs, making mergeJniLibFolders see each .so twice and
-// fail with "Duplicate resources". Tell the merge Copy task to silently keep
-// one copy.
-tasks.matching {
-    it.name.startsWith("merge") && it.name.endsWith("JniLibFolders")
-}.configureEach {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+// rust-android-gradle 0.9.6 ends up registering its build/rustJniLibs/<abi>
+// directory in jniLibs.srcDirs twice under AGP 8.5+, causing
+// mergeJniLibFolders to fail with "Duplicate resources" on every ABI's .so.
+// Deduplicate srcDirs at configure time. MergeSourceSetFolders is not a
+// Copy task, so duplicatesStrategy doesn't help here.
+afterEvaluate {
+    android.sourceSets.configureEach { sourceSet ->
+        sourceSet.jniLibs.srcDirs = sourceSet.jniLibs.srcDirs.toSet().toList()
+    }
 }
 
 cargo {

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,13 @@
 buildscript {
     ext.kotlin_version = '1.9.25'
     repositories {
+        // Use Google's China mirror so the build works from networks where
+        // dl.google.com is unreachable. The mirror serves the same artifacts.
+        maven { url 'https://dl.google.cn/dl/android/maven2/' }
         google()
+        maven { url 'https://maven.aliyun.com/repository/central' }
         mavenCentral()
+        maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
         gradlePluginPortal()
     }
     dependencies {
@@ -19,7 +24,9 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url 'https://dl.google.cn/dl/android/maven2/' }
         google()
+        maven { url 'https://maven.aliyun.com/repository/central' }
         mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '1.9.10'
     repositories {
         // Use Google's China mirror so the build works from networks where
         // dl.google.com is unreachable. The mirror serves the same artifacts.
@@ -13,7 +13,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.25'
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.7-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Google Play has required apps to target **API 35 (Android 15)** since Nov 1, 2025; the current `targetSdk 33` makes new uploads rejected. Bump the SDK levels and the toolchain required to compile against them.

| Setting | Before | After |
|---|---|---|
| AGP | 8.1.2 | 8.5.0 |
| Gradle wrapper | 8.4 | 8.7 |
| Kotlin | 1.9.10 | 1.9.25 |
| Compose Compiler ext | 1.5.3 | 1.5.15 |
| compileSdk | 34 | 35 |
| minSdk | 21 | 24 |
| targetSdk | 33 | 35 |

`minSdk 24` covers ~97 % of active Play devices and matches the practical baseline for current AndroidX / Compose dependencies.

`compileSdk 35` requires AGP 8.5+ — AGP 8.5.0 is the smallest jump that gets us there. JDK 17 and NDK 25.1.8937393 unchanged.

Couldn't validate locally (gradle's HTTP client can't tunnel through my local proxy cleanly); relying on CI to verify the toolchain combination compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
