### PR TITLE
Bump compileSdk/targetSdk to 36 for Google Play 2025/2026 policy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ if (localPropsFile.exists()) {
 
 android {
     namespace 'org.proxydroid'
-    compileSdk 34
+    compileSdk 36
     ndkVersion "25.1.8937393"
 
     signingConfigs {
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         applicationId "org.proxydroid"
         minSdk 24
-        targetSdk 35
+        targetSdk 36
         versionCode 74
         versionName "3.4.0"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,8 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# AGP 8.1.2 only officially supports compileSdk 34; suppress the unsupported
+# compileSdk error so we can target API 36 (Android 16) for Google Play's
+# 2025/2026 policy without bumping AGP (which retriggers the
+# rust-android-gradle 0.9.6 mergeJniLibFolders duplicate-resources bug).
+android.suppressUnsupportedCompileSdk=36


### PR DESCRIPTION
Google Play requires new apps to target API 36 (Android 16) by Aug 31, 2025 and updates by Nov 1, 2025. Previous target 35 satisfied the 2024 deadline but trips the 2025 warning in Play Console.

## Changes
- `app/build.gradle`: `compileSdk 34 → 36`, `targetSdk 35 → 36`. `minSdk 24` unchanged.
- `gradle.properties`: `android.suppressUnsupportedCompileSdk=36` so AGP 8.1.2 stops erroring on the newer compileSdk.

## Why not bump AGP
AGP 8.1.2 officially caps at compileSdk 34, but bumping AGP retriggers the rust-android-gradle 0.9.6 `mergeJniLibFolders` duplicate-resources bug we already had to work around (see 0249f91 / 8875c74). The suppression flag is the lighter fix.

## Verified
- `./gradlew :app:assembleDebug` green.
- `scripts/run_local_emulator_tests.sh` on AVD `meow_api35` (arm64-v8a, API 35): **8/8 e2e tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)